### PR TITLE
Fix handyhelpers ImportError

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ psycopg[binary]==3.1.17
 pytest==8.0.0
 pytest-django==4.8.0
 sqlparse==0.4.4
-django-handyhelpers>=0.3.14
+django-handyhelpers==0.3.16

--- a/src/web/views.py
+++ b/src/web/views.py
@@ -23,8 +23,7 @@ class Index(HandyHelperIndexView):
                 "title": str(tech_group),
                 "description": (tech_group.description or "")[:100],
             }
-            for tech_group in
-            TechGroup.objects.all()
+            for tech_group in TechGroup.objects.all()
         ]
         super().__init__(**kwargs)
 
@@ -45,27 +44,29 @@ class DetailEvent(DetailView):
 
 def list_tech_groups(request: HttpRequest) -> HttpResponse:
     groups = TechGroup.objects.all()
-    return render(request, "web/list_tech_groups.html", { "groups": groups })
+    return render(request, "web/list_tech_groups.html", {"groups": groups})
 
 
 def get_tech_group(request: HttpRequest, pk: int) -> HttpResponse:
     group = TechGroup.objects.get(pk=pk)
-    return render(request, "web/get_tech_group.html", { "group": group })
+    return render(request, "web/get_tech_group.html", {"group": group})
 
 
 def get_event(request: HttpRequest, pk: int) -> HttpResponse:
     event = Event.objects.get(pk=pk)
-    return render(request, "web/get_tech_group.html", { "event": event })
+    return render(request, "web/get_tech_group.html", {"event": event})
 
 
 class GetTechGroups(HtmxSidebarItems):
     """Get a list of enabled TechGroups and render a partial to use on the sidebar navigation"""
+
     template_name = "web/partials/sidebar_items.htm"
     queryset = TechGroup.objects.filter(enabled=True)
 
 
 class GetEvents(HtmxSidebarItems):
     """Get a list of upcoming Events and render a partial to use on the sidebar navigation"""
+
     template_name = "web/partials/sidebar_items.htm"
 
     def __init__(self, **kwargs):

--- a/src/web/views.py
+++ b/src/web/views.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from django.views.generic import DetailView
 from handyhelpers.views.gui import HandyHelperListView, HandyHelperIndexView
-from handyhelpers.views.htmx import GenericHtmxView
+from handyhelpers.views.htmx import HtmxSidebarItems
 
 from web.models import Event, TechGroup
 
@@ -58,13 +58,13 @@ def get_event(request: HttpRequest, pk: int) -> HttpResponse:
     return render(request, "web/get_tech_group.html", { "event": event })
 
 
-class GetTechGroups(GenericHtmxView):
+class GetTechGroups(HtmxSidebarItems):
     """Get a list of enabled TechGroups and render a partial to use on the sidebar navigation"""
     template_name = "web/partials/sidebar_items.htm"
     queryset = TechGroup.objects.filter(enabled=True)
 
 
-class GetEvents(GenericHtmxView):
+class GetEvents(HtmxSidebarItems):
     """Get a list of upcoming Events and render a partial to use on the sidebar navigation"""
     template_name = "web/partials/sidebar_items.htm"
 


### PR DESCRIPTION
Fixes #43 

Changed `GenericHtmxView` -> `HtmxSidebarItems`
Pinned `django-handyhelpers` to `0.3.16`.

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [x] Documentation has been updated.
