### PR TITLE
Remove collectstatic from post_deploy script temporarily

### DIFF
--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -2,4 +2,3 @@
 set -e
 cd ./src
 python manage.py migrate
-python manage.py collectstatic --noinput


### PR DESCRIPTION
## Pull Request

**Description:**
- Remove `python manage.py collectstatic` from post_deploy.sh temporarily to fix timeout

**Checklist:**
- [ ] All tests pass.
- [ ] Code follows the project's coding standards.
- [ ] Documentation has been updated.
