### PR TITLE
Add back collectstatic to post_deploy.sh

### DIFF
--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -2,3 +2,7 @@
 set -e
 cd ./src
 python manage.py migrate
+
+# `node_modules` static folder is huge so ignore it
+# If `node_modules` is updated, run collectstatic manually
+python manage.py collectstatic --noinput -v=2 --ignore node_modules


### PR DESCRIPTION
## Pull Request

**Description:**
Adds back `collectstatic` command to Fly.io's [deploy](https://fly.io/docs/reference/configuration/#run-one-off-commands-before-releasing-a-deployment) script. Ignores the very large `node_modules` folder since it's too big, causing the release to timeout before completing.

**Related Issues:**
- https://github.com/SpokaneTech/SpokaneTech_Py/issues/31

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [x] Documentation has been updated.
