### PR TITLE
Fix celery periodic tasks running multiple times per hour

### DIFF
--- a/src/spokanetech/celery.py
+++ b/src/spokanetech/celery.py
@@ -19,6 +19,6 @@ if settings.CELERY_ENABLED:
         },
         "Send Events to Discord": {
             "task": "web.tasks.send_events_to_discord",
-            "schedule": crontab(day_of_week="mon"),
+            "schedule": crontab(day_of_week="mon", hour="0", minute="0"),
         },
     }

--- a/src/spokanetech/celery.py
+++ b/src/spokanetech/celery.py
@@ -15,7 +15,7 @@ if settings.CELERY_ENABLED:
     app.conf.beat_schedule = {
         "Scrape Events from Meetup": {
             "task": "web.tasks.scrape_events_from_meetup",
-            "schedule": crontab(hour="0"),
+            "schedule": crontab(hour="0", minute="0"),
         },
         "Send Events to Discord": {
             "task": "web.tasks.send_events_to_discord",

--- a/src/spokanetech/settings.py
+++ b/src/spokanetech/settings.py
@@ -198,6 +198,7 @@ except KeyError:
         raise
 
 CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", "django-db")
+CELERY_RESULT_EXTENDED = True
 CELERY_ACCEPT_CONTENT = ["application/json"]
 CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"


### PR DESCRIPTION
## Pull Request

**Description:**
- Fix celery periodic tasks running multiple times per hour
- Add more info to Celery tasks results
    - > If you want to include extended information about your tasks remember to enable the [result_extended](https://docs.celeryq.dev/en/master/userguide/configuration.html#std-setting-result_extended) setting.
      > \- https://django-celery-results.readthedocs.io/en/latest/getting_started.html

**Related Issues:**
- #73

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [ ] Documentation has been updated.


### Screenshots
Now the task name fields are populated in the admin:
![image](https://github.com/SpokaneTech/SpokaneTech_Py/assets/19392916/5e768ee2-7f6a-4420-8532-0db7d8ddc25e)
