### PR TITLE
#87: Set and use the user's timezone in sesson storage

### DIFF
--- a/src/spokanetech/settings.py
+++ b/src/spokanetech/settings.py
@@ -79,6 +79,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "web.middleware.TimezoneMiddleware",
 ]
 
 ROOT_URLCONF = "spokanetech.urls"

--- a/src/templates/spokanetech/base.html
+++ b/src/templates/spokanetech/base.html
@@ -10,6 +10,27 @@
 <title>Spokane Tech</title>
 {% endblock favicon %}
 
+{% block app_javascript %}
+<script>
+  const TIMEZONE_ID = "TIMEZONE_ID"
+
+  $(document).ready(() => {
+    const timezoneID = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const storedTimezone = window.localStorage.getItem(TIMEZONE_ID)
+    if (!storedTimezone || storedTimezone != timezoneID) {
+      $.post({
+        url: "/set_timezone/",
+        data: { "timezone": timezoneID },
+        headers: { "X-CSRFToken": csrftoken }, // handyhelpers base template defines `csrftoken`
+        success: (data) => {
+          window.localStorage.setItem(TIMEZONE_ID, timezoneID)
+        },
+      })
+    }
+  })
+</script>
+{% endblock app_javascript %}
+
 {% block sidebar %}
 {% include 'spokanetech/sidebar.htm' %}
 {% endblock sidebar %}

--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -1,0 +1,16 @@
+from typing import Callable
+
+import pytz
+from django.http import HttpRequest, HttpResponse
+from django.utils import timezone
+
+
+class TimezoneMiddleware:
+    def __init__(self, get_response: Callable[[HttpRequest], HttpResponse]):
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest):
+        if timezone_id := request.session.get("timezone"):
+            timezone.activate(pytz.timezone(timezone_id))
+
+        return self.get_response(request)

--- a/src/web/services.py
+++ b/src/web/services.py
@@ -1,5 +1,5 @@
-from typing import Protocol
 from datetime import timedelta
+from typing import Protocol
 
 from django.forms.models import model_to_dict
 from django.utils import timezone
@@ -43,7 +43,7 @@ class DiscordService:
 
     def send_events(self) -> None:
         """Send upcoming events to the Discord server."""
-        today = timezone.localdate()
+        today = timezone.localtime()
         events = (
             models.Event.objects.filter(
                 date_time__gte=today,
@@ -56,7 +56,8 @@ class DiscordService:
         message = "_Here are the upcoming Spokane Tech events for this week:_\n\n"
         for event in events:
             event_url = event.url if event.url else f"https://spokanetech.org{event.get_absolute_url()}"
-            event_msg = f"**{event.date_time.strftime('%A, %b %d @ %-I:%M %p')}**\n"
+            unix_timestamp = int(event.date_time.timestamp())
+            event_msg = f"<t:{unix_timestamp}:F>\n"
             if event.group:
                 event_msg += f"{event.group.name} — "
             event_msg += f"[{event.name}](<{event_url}>)"

--- a/src/web/services.py
+++ b/src/web/services.py
@@ -57,7 +57,7 @@ class DiscordService:
         for event in events:
             event_url = event.url if event.url else f"https://spokanetech.org{event.get_absolute_url()}"
             unix_timestamp = int(event.date_time.timestamp())
-            event_msg = f"<t:{unix_timestamp}:F>\n"
+            event_msg = f"**<t:{unix_timestamp}:F>**\n"
             if event.group:
                 event_msg += f"{event.group.name} — "
             event_msg += f"[{event.name}](<{event_url}>)"

--- a/src/web/templates/web/partials/table/table_events.htm
+++ b/src/web/templates/web/partials/table/table_events.htm
@@ -18,7 +18,7 @@
           <a href="{{ event.group.get_absolute_url }}">{{ event.group }}</a>
         </td>
         <td>{{ event.description|markdownify }}</td>
-        <td>
+        <td data-testid="date_time">
           {% include 'spokanetech/partials/human_readable_datetime.htm' with object=event only %}
         </td>
         <td>{{ event.duration }} hour{{ event.duration|pluralize }}</td>

--- a/src/web/tests/test_tasks.py
+++ b/src/web/tests/test_tasks.py
@@ -1,10 +1,8 @@
 from datetime import timedelta
 
 import freezegun
-
 from django.test import TestCase
 from django.utils import timezone
-
 from web import models, services
 
 
@@ -45,10 +43,10 @@ class TestSendEventsToDiscord(TestCase):
 
         expected = f"""_Here are the upcoming Spokane Tech events for this week:_
 
-**Tuesday, Mar 19 @ 12:00 AM**
+**<t:1710806400:F>**
 Spokane Python User Group — [Intro to Python](<https://spokanepython.com/meetups/intro-to-python/>)
 
-**Wednesday, Mar 20 @ 6:00 PM**
+**<t:1710957600:F>**
 Spokane Python User Group — [Advanced Python](<https://spokanetech.org/events/{event2.pk}>)
 
 """

--- a/src/web/tests/test_views.py
+++ b/src/web/tests/test_views.py
@@ -1,11 +1,13 @@
+from datetime import datetime
+
+import freezegun
+import pytest
+from bs4 import BeautifulSoup
 from django.test import TestCase
 from django.test.client import Client
 from django.urls import reverse
 from django.utils import timezone
-
 from model_bakery import baker
-import pytest
-
 from web.models import TechGroup
 
 
@@ -47,6 +49,25 @@ def test_get_tech_group(client: Client):
     # Assert
     assert response.status_code == 200
     assert response.context["object"].pk == tech_group.pk
+
+
+@freezegun.freeze_time("2024-03-17")
+@pytest.mark.django_db
+def test_set_timezone_and_timezone_middleware(client: Client):
+    # Arrange
+    date_time = datetime.fromisoformat("2024-03-19T01:00:00Z")
+    baker.make("web.Event", date_time=date_time)
+
+    # Act
+    client.post(reverse("web:set_timezone"), {"timezone": "America/Los_Angeles"})
+    response = client.get(reverse("web:events"))
+
+    # Assert
+    soup = BeautifulSoup(response.content, "lxml")
+    date_time_tag = soup.find(attrs={"data-testid": "date_time"})
+    assert date_time_tag is not None
+    actual = date_time_tag.text.strip()
+    assert actual == "Monday, March 18, 2024 at 6:00 PM"
 
 
 class TestEventDetailModal(TestCase):

--- a/src/web/urls.py
+++ b/src/web/urls.py
@@ -6,6 +6,7 @@ app_name = "web"
 
 urlpatterns = [
     path("", views.Index.as_view(), name="index"),
+    path("set_timezone/", views.set_timezone, name="set_timezone"),
     path("events", views.ListEvents.as_view(), name="events"),
     path("groups", views.list_tech_groups, name="list_tech_groups"),
     path("groups/<int:pk>", views.DetailTechGroup.as_view(), name="get_tech_group"),

--- a/src/web/views.py
+++ b/src/web/views.py
@@ -4,6 +4,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.template import loader
 from django.utils import timezone
+from django.views.decorators.http import require_http_methods
 from django.views.generic import DetailView
 from handyhelpers.mixins.view_mixins import HtmxViewMixin
 from handyhelpers.views.calendar import CalendarView
@@ -11,6 +12,13 @@ from handyhelpers.views.gui import HandyHelperIndexView, HandyHelperListView
 from handyhelpers.views.htmx import BuildBootstrapModalView, BuildModelSidebarNav
 
 from web.models import Event, TechGroup
+
+
+@require_http_methods(["POST"])
+def set_timezone(request: HttpRequest) -> HttpResponse:
+    timezone_id = request.POST["timezone"]
+    request.session["timezone"] = timezone_id
+    return HttpResponse()
 
 
 class Index(HandyHelperIndexView):


### PR DESCRIPTION
## Pull Request

**Description:**
- Detect the user's timezone via JS and store it in the Django session (also cache it in the browser local storage)
- Use the timezone from the session storage to set the current timezone for the scope of the request via middleware
- Add test for the above items

**Related Issues:**
- fix #87

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [ ] Documentation has been updated.
