### PR TITLE
Replace pytz with zoneinfo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ discord.py==2.3.2
 dj-database-url==2.1.0
 django-celery-beat==2.6.0
 django-celery-results==2.5.1
-django-handyhelpers==0.3.20
+django-handyhelpers==0.3.22
 django-markdownify==0.9.3
 django-storages[azure]==1.14.2
 Django==5.0.1

--- a/src/web/middleware.py
+++ b/src/web/middleware.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-import pytz
+import zoneinfo
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 
@@ -11,6 +11,6 @@ class TimezoneMiddleware:
 
     def __call__(self, request: HttpRequest):
         if timezone_id := request.session.get("timezone"):
-            timezone.activate(pytz.timezone(timezone_id))
+            timezone.activate(zoneinfo.ZoneInfo(timezone_id))
 
         return self.get_response(request)


### PR DESCRIPTION
## Pull Request

**Description:**
- Replace deprecated pytz module with zoneinfo
    - See https://docs.djangoproject.com/en/5.0/releases/4.0/#zoneinfo-default-timezone-implementation and https://blog.ganssle.io/articles/2018/03/pytz-fastest-footgun.html
    - This will fix not being able to accurately update times in the admin while using the TimezoneMiddleware
- Upgrade django-handyhelpers to [remove pytz dependency](https://github.com/davidslusser/django-handyhelpers/pull/125)

**Related Issues:**
- closes #96

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [ ] Documentation has been updated.
