### PR TITLE
feat: Default to pacific timezone

### DIFF
--- a/src/spokanetech/settings.py
+++ b/src/spokanetech/settings.py
@@ -161,7 +161,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+TIME_ZONE = "America/Los_Angeles"
 
 USE_I18N = True
 


### PR DESCRIPTION
## Pull Request

**Description:**
Default the timezone to Pacific time (`America/Los_Angeles`) in the event that a user has JS disabled and we can't detect their browser timezone.

**Related Issues:**
- #96

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [x] Documentation has been updated.
