### PR TITLE
Move `pytest` configuration into `pyproject.toml`

### DIFF
--- a/dagger/src/main.py
+++ b/dagger/src/main.py
@@ -174,19 +174,18 @@ class SpokaneTech:
                 "-vv",
                 "--config-file",
                 "pyproject.toml",
-                "-k",
-                "not integration",
                 "src",
             ],
             ctr,
         )
 
     @function
-    async def all_linters(self, pyproject: dagger.File, dev_req: dagger.File, verbose: bool = False) -> str:
+    async def all_linters(self, pyproject: dagger.File, dev_req: dagger.File) -> str:
         """
         Runs all the liners.
         Pass `--verbose` to not summarize linter output.
         """
+        verbose = False
         # Run all the linters
         async with TaskGroup() as tg:
             tasks = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,14 @@ exclude_dirs = [".venv", "venv", "tests"]
 line-length = 120
 exclude = ["src/*/migrations", "src/manage.py"]
 
+[tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "spokanetech.settings"
+addopts = "-vv --reuse-db"
+markers = [
+  "integration",
+  "eventbrite",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-DJANGO_SETTINGS_MODULE = spokanetech.settings
-addopts = -vv --reuse-db
-markers =
-  integration

--- a/src/web/tests/conftest.py
+++ b/src/web/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+
+import pytest
+
+
+def pytest_runtest_setup(item):
+    for _ in item.iter_markers(name="eventbrite"):
+        if not os.environ.get("EVENTBRITE_API_TOKEN"):
+            pytest.skip()

--- a/src/web/tests/test_scrapers.py
+++ b/src/web/tests/test_scrapers.py
@@ -116,8 +116,16 @@ class TestMeetupEventScraper(TestCase):
         }
 
 
-@pytest.mark.integration
+@pytest.mark.eventbrite
 class TestEventbriteScraper(TestCase):
+    """
+    The Eventbrite API requires a (free) API token,
+    rather than requiring that each contributer maintain their own token,
+    theses tests are not included in by default.
+
+    To run them, set the `EVENTBRITE_API_TOKEN` envrionment variable.
+    """
+
     def test_scraper(self):
         scraper = scrapers.EventbriteScraper()
         result = scraper.scrape("72020528223")


### PR DESCRIPTION
## Pull Request

**Description:**
- Moved `pytest.ini` configuration into `pyproject.toml`
- Added Pytest hook to skip Eventbrite tests when the `EVENTBRITE_API_TOKEN` environment variable is unset or empty.

**Related Issues:**
- #124 

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [x] Documentation has been updated.

---

The failing Eventbrite test was annoying me so I added a hook to skip them if the API token is unset or empty. The tests will show up as skipped in the test result, I added a comment to the test source, and I assume that contributes that touch the Eventbrite code will probably have and API key and/or touch the test code too.

![image](https://github.com/user-attachments/assets/566bdd90-c7d7-4758-b9c4-50d41ffb695c)

