### PR TITLE
Remove collectstatic from deployment for now

### DIFF
--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -5,4 +5,4 @@ python manage.py migrate
 
 # `node_modules` static folder is huge so ignore it
 # If `node_modules` is updated, run collectstatic manually
-python manage.py collectstatic --noinput -v=2 --ignore node_modules
+# python manage.py collectstatic --noinput -v=2 --ignore node_modules


### PR DESCRIPTION
## Pull Request

**Description:**

Remove `collectstatic` command from post deployment script for now as it takes too long and has issues with deleting/re-uploading files. This is preventing the site from restarting.

**Related Issues:**
- #113

**Checklist:**
- [x] All tests pass.
- [x] Code follows the project's coding standards.
- [ ] Documentation has been updated.
